### PR TITLE
Add support for signature tags

### DIFF
--- a/bin/git-signatures
+++ b/bin/git-signatures
@@ -292,6 +292,10 @@ cmd_add() {
 		| openssl base64 -A \
 	)
 	printf "%s" "$signature" | git notes --ref signatures append --file=-
+
+	TAG_TARGET=$(git rev-parse refs/tags/latest-signature)
+	[ "$?" -eq 0 ] && git tag -f latest-signature $TAG_TARGET
+
 	[[ "$push" -eq "0" ]] || $PROGRAM push
 }
 
@@ -350,8 +354,14 @@ cmd_init() {
 		remote.origin.fetch \
 		"+refs/notes/signatures:refs/notes/signatures"
 	git config --add \
+		remote.origin.fetch \
+		"+refs/tags/latest-signature:refs/tags/latest-signature"
+	git config --add \
 		remote.origin.push \
 		"+refs/notes/signatures:refs/notes/signatures"
+	git config --add \
+		remote.origin.push \
+		"+refs/tags/latest-signature:refs/tags/latest-signature"
 }
 
 cmd_import() {
@@ -372,13 +382,25 @@ cmd_import() {
 
 cmd_pull() {
 	[ "$#" -eq 0 ] || { usage pull; exit 1; }
-	git fetch origin refs/notes/signatures:refs/notes/origin/signatures
+
+	git rev-parse refs/tags/latest-signature >/dev/null 2>&1
+	if [ "$?" -eq 0 ]; then
+		git fetch origin refs/notes/signatures:refs/notes/origin/signatures +refs/tags/latest-signature:refs/tags/origin/latest-signature
+	else
+		git fetch origin refs/notes/signatures:refs/notes/origin/signatures
+	fi
 	git notes --ref signatures merge -s cat_sort_uniq origin/signatures
 }
 
 cmd_push() {
 	[ "$#" -eq 0 ] || { usage push; exit 1; }
-	git push origin refs/notes/signatures
+
+	git rev-parse refs/tags/latest-signature >/dev/null 2>&1
+	if [ "$?" -eq 0 ]; then
+		git push origin refs/notes/signatures +refs/tags/latest-signature
+	else
+		git push origin refs/notes/signatures
+	fi
 }
 
 main "$@"


### PR DESCRIPTION
* The idea here is we'd like to get a webhook notification when the
signatures notes ref changes. Unfortunately, github does not fire
webhooks for refs outside refs/heads or refs/tags. To get webhooks to
fire for these events, we just create a tag which moves each time the
signatures notes ref is updated, and push that tag, which will fire off
a webhook. Note that the actual commit that the tag points to is of
absolutely no importance and one should not rely on the latest-signature
tag to actually point at the latest signature, any notes ref, or really
anything of use.

Signed-off-by: Tyler Levine <tyler@bitgo.com>